### PR TITLE
Remove query_string from callback_url.

### DIFF
--- a/lib/omniauth/strategies/instagram.rb
+++ b/lib/omniauth/strategies/instagram.rb
@@ -9,6 +9,10 @@ module OmniAuth
         :token_url => 'https://api.instagram.com/oauth/access_token'
       }
 
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       def request_phase
         options[:scope] ||= 'basic'
         options[:response_type] ||= 'code'


### PR DESCRIPTION
For some reasons, Instagram decided not to accept `query_string` as part of the `redirect_uri` in their oauth2's `https://api.instagram.com/oauth/access_token` request.

Instagram should probably be the one to fix this since their documentation clearly states that extra parameters can be passed along and it can still be valid: https://instagram.com/developer/authentication/.